### PR TITLE
Add "Akâmandra" as additonal consumable

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -960,7 +960,8 @@
         },
         "consumable": {
             "category": {
-                "0": "Duftkugel"
+                "0": "Duftkugel",
+                "1": "Akâmandra"
             },
             "qs": {
                 "0": "Schwach",

--- a/modules/item/item_sheet_dsk.js
+++ b/modules/item/item_sheet_dsk.js
@@ -183,7 +183,8 @@ class ItemSheetConsumable extends ItemSheetObfuscation(ItemSheetDSK) {
             calculatedPrice: game.dsk.config.ItemSubClasses.consumable.consumablePrice(this.item),
             qsOptions: Array.fromRange(3, 0).reduce((acc, x) => { acc[x] = game.i18n.localize(`dsk.consumable.qs.${x}`); return acc }, {}),
             consumableCategories: {
-                "0": 'dsk.consumable.category.0'
+                "0": 'dsk.consumable.category.0',
+                "1": 'dsk.consumable.category.1'
             }
         })
         return data


### PR DESCRIPTION
Hi, 

ich habe das jetzt **nicht** testen können, da ich mich erst selber in die Module Entwicklung einarbeiten muss.
Glaube aber dieser kleine Patch sollte "Akâmandra" als weitere consumable Kategorie hinzufügen.

Bin dankbar für Feedback falls es noch nicht richitg sein sollte.